### PR TITLE
Fix package.json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sitepoint front end test",
   "main": "index.js",
   "scripts": {
-    "start" : "node index.js",
+    "start" : "node index.js"
   },
   "keywords": [
     "sitepoint"


### PR DESCRIPTION
`npm install` currently fails due to a trailing comma in `package.json` causing the JSON parser to fail.

```
npm ERR! Failed to parse json
npm ERR! Unexpected token }
npm ERR! File: frontend-test/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
```
